### PR TITLE
Fix spacing issue in EditModal component 

### DIFF
--- a/src/components/LeftPanel/EditModal.tsx
+++ b/src/components/LeftPanel/EditModal.tsx
@@ -90,7 +90,7 @@ const EditModal: React.FC<EditModalProps> = ({ open, onClose, workspace }) => {
             label="New Workspace Name..."
             variant="outlined" // Change variant to outlined for a cleaner look
             fullWidth // Take up full width
-            className="mb-2" // Add margin bottom
+            sx={{mb : 2}} // Add margin bottom
             onChange={(e) => setNewName(e.target.value)}
           />
           <TextField
@@ -98,7 +98,7 @@ const EditModal: React.FC<EditModalProps> = ({ open, onClose, workspace }) => {
             label="New Description..."
             variant="outlined" // Change variant to outlined for a cleaner look
             fullWidth // Take up full width
-            className="mb-2" // Add margin bottom
+            sx={{mb : 2}} // Add margin bottom
             onChange={(e) => setNewDescription(e.target.value)}
           />
           <Button


### PR DESCRIPTION
Fixes #16: 

This pull request addresses a UI issue in the EditModal component where the TextField components for "New Workspace Name" and "New Description" were not properly spaced, leading to an inconsistent layout.

Changes Made:
Issue Description:
The TextField components used in the EditModal component had inconsistent spacing due to the use of className="mb-2" for adding bottom margin. This caused the fields to appear cramped and not aligned properly with the rest of the modal's content.

Rectification:
The solution involved changing the way margin is applied to the TextField components. Instead of using className, the sx prop from MUI was used to ensure consistent and clean styling. The sx prop allows for inline styling directly within the component, which is a more modern and preferred approach in MUI.